### PR TITLE
Update celeste-core to use Git source instead of workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dev = [
 ]
 
 [tool.uv.sources]
-celeste-core = { workspace = true }
+celeste-core = { git = "https://github.com/celeste-kai/celeste-core.git" }
+


### PR DESCRIPTION
## Summary
- Updated celeste-core dependency to use Git source instead of workspace reference
- This fixes UV workspace configuration issues while maintaining external installability

## Test plan
- [x] UV sync runs successfully
- [x] Package builds correctly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)