### PR TITLE
refactor: standardize model attribute naming across providers

### DIFF
--- a/src/celeste_audio_intelligence/providers/google.py
+++ b/src/celeste_audio_intelligence/providers/google.py
@@ -39,7 +39,7 @@ class GoogleAudioClient(BaseAudioClient):
             raise ValueError("AudioFile must have either data or file_path")
 
         response = await self.client.aio.models.generate_content(
-            model=self.model_name,
+            model=self.model,
             contents=[prompt, audio],
             **kwargs,
         )
@@ -48,7 +48,7 @@ class GoogleAudioClient(BaseAudioClient):
         return AIResponse(
             content=response.text,
             provider=Provider.GOOGLE,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -60,13 +60,13 @@ class GoogleAudioClient(BaseAudioClient):
         audio = await self.client.aio.files.upload(file=audio_file.file_path)
 
         async for chunk in await self.client.aio.models.generate_content_stream(
-            model=self.model_name, contents=[prompt, audio], **kwargs
+            model=self.model, contents=[prompt, audio], **kwargs
         ):
             if chunk.text:  # Only yield if there's actual content
                 yield AIResponse(
                     content=chunk.text,
                     provider=Provider.GOOGLE,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )
 
         # suppress final usage-only emission

--- a/src/celeste_audio_intelligence/providers/openai.py
+++ b/src/celeste_audio_intelligence/providers/openai.py
@@ -15,10 +15,10 @@ class OpenAIAudioClient(BaseAudioClient):
 
     def __init__(self, model: str = "whisper-1", **kwargs: Any) -> None:
         self.client = openai.AsyncOpenAI(api_key=settings.openai.api_key)
-        self.model_name = model
+        self.model = model
         # Non-raising validation; store support state for callers to inspect if needed
         self.is_supported = supports(
-            Provider.OPENAI, self.model_name, Capability.AUDIO_TRANSCRIPTION
+            Provider.OPENAI, self.model, Capability.AUDIO_TRANSCRIPTION
         )
 
     async def generate_content(
@@ -37,7 +37,7 @@ class OpenAIAudioClient(BaseAudioClient):
             audio_buffer = io.BytesIO(audio_file.data)
             audio_buffer.name = audio_file.filename or "audio.mp3"
             response = await self.client.audio.transcriptions.create(
-                model=self.model_name,
+                model=self.model,
                 file=audio_buffer,
                 prompt=prompt,  # Optional context prompt for better accuracy
                 **kwargs,
@@ -46,7 +46,7 @@ class OpenAIAudioClient(BaseAudioClient):
             # Use file path
             with open(audio_file.file_path, "rb") as audio:
                 response = await self.client.audio.transcriptions.create(
-                    model=self.model_name,
+                    model=self.model,
                     file=audio,
                     prompt=prompt,  # Optional context prompt for better accuracy
                     **kwargs,
@@ -59,7 +59,7 @@ class OpenAIAudioClient(BaseAudioClient):
             content=response.text,
             provider=Provider.OPENAI,
             metadata={
-                "model": self.model_name,
+                "model": self.model,
                 "prompt_used": prompt,  # Include prompt in metadata for transparency
             },
         )


### PR DESCRIPTION
## Summary
- Replace `model_name` with `model` attribute across Google and OpenAI audio clients
- Improves API consistency and follows standard naming conventions
- Ensures uniform interface across all provider implementations

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] No functional changes to existing behavior
- [x] Attribute standardization maintains backward compatibility within internal usage

🤖 Generated with [Claude Code](https://claude.ai/code)