### PR TITLE
fix: optimize import statements in audio providers

### DIFF
--- a/src/celeste_audio_intelligence/providers/google.py
+++ b/src/celeste_audio_intelligence/providers/google.py
@@ -1,3 +1,4 @@
+import io
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -20,8 +21,6 @@ class GoogleAudioClient(BaseAudioClient):
 
     async def generate_content(self, prompt: str, audio_file: AudioArtifact, **kwargs: Any) -> AIResponse:
         """Generate text from a prompt and a list of documents."""
-        import io
-
         # Handle both file path and bytes
         if audio_file.data:
             # Upload bytes directly

--- a/src/celeste_audio_intelligence/providers/openai.py
+++ b/src/celeste_audio_intelligence/providers/openai.py
@@ -1,3 +1,4 @@
+import io
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -27,8 +28,6 @@ class OpenAIAudioClient(BaseAudioClient):
         For Whisper: prompt provides context for better accuracy
         For GPT-4o-transcribe: prompt can guide the transcription output
         """
-        import io
-
         # Handle both file path and bytes
         if audio_file.data:
             # Use bytes directly with BytesIO


### PR DESCRIPTION
## Summary
- Move `io` import to module level in Google and OpenAI audio providers
- Improves code organization and performance by avoiding repeated imports

## Changes
- `src/celeste_audio_intelligence/providers/google.py`: Move `io` import to top of file
- `src/celeste_audio_intelligence/providers/openai.py`: Move `io` import to top of file

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Verify audio transcription still works with Google provider
- [ ] Verify audio transcription still works with OpenAI provider

🤖 Generated with [Claude Code](https://claude.ai/code)