### PR TITLE
Add structured output support for Google audio client

### DIFF
--- a/src/celeste_audio_intelligence/providers/google.py
+++ b/src/celeste_audio_intelligence/providers/google.py
@@ -2,6 +2,8 @@ import io
 from collections.abc import AsyncIterator
 from typing import Any
 
+from pydantic import BaseModel
+
 from celeste_core import AIResponse, AudioArtifact, Provider
 from celeste_core.base.audio_client import BaseAudioClient
 from celeste_core.config.settings import settings
@@ -19,7 +21,13 @@ class GoogleAudioClient(BaseAudioClient):
         )
         self.client = genai.Client(api_key=settings.google.api_key)
 
-    async def generate_content(self, prompt: str, audio_file: AudioArtifact, **kwargs: Any) -> AIResponse:
+    async def generate_content(
+        self,
+        prompt: str,
+        audio_file: AudioArtifact,
+        structured_output: BaseModel | list[BaseModel] | None = None,
+        **kwargs: Any,
+    ) -> AIResponse:
         """Generate text from a prompt and a list of documents."""
         # Handle both file path and bytes
         if audio_file.data:
@@ -33,35 +41,58 @@ class GoogleAudioClient(BaseAudioClient):
         else:
             raise ValueError("AudioArtifact must have either data or path")
 
+        request_kwargs = dict(kwargs)
+        if structured_output is not None:
+            request_kwargs["config"] = {
+                "response_mime_type": "application/json",
+                "response_schema": structured_output,
+            }
+
         response = await self.client.aio.models.generate_content(
             model=self.model,
             contents=[prompt, audio],
-            **kwargs,
+            **request_kwargs,
         )
 
         # Return AIResponse object
         return AIResponse(
-            content=response.text,
+            content=getattr(response, "parsed", response.text),
             provider=Provider.GOOGLE,
             metadata={"model": self.model},
         )
 
     async def stream_generate_content(
-        self, prompt: str, audio_file: AudioArtifact, **kwargs: Any
+        self,
+        prompt: str,
+        audio_file: AudioArtifact,
+        structured_output: BaseModel | list[BaseModel] | None = None,
+        **kwargs: Any,
     ) -> AsyncIterator[AIResponse]:
         """Streams the response chunk by chunk."""
 
         # Upload the audio file
         audio = await self.client.aio.files.upload(file=audio_file.path)
 
+        request_kwargs = dict(kwargs)
+        if structured_output is not None:
+            request_kwargs["config"] = {
+                "response_mime_type": "application/json",
+                "response_schema": structured_output,
+            }
+
         async for chunk in await self.client.aio.models.generate_content_stream(
-            model=self.model, contents=[prompt, audio], **kwargs
+            model=self.model, contents=[prompt, audio], **request_kwargs
         ):
-            if chunk.text:  # Only yield if there's actual content
-                yield AIResponse(
-                    content=chunk.text,
-                    provider=Provider.GOOGLE,
-                    metadata={"model": self.model, "is_stream_chunk": True},
-                )
+            parsed_content = getattr(chunk, "parsed", None)
+            text_content = getattr(chunk, "text", None)
+
+            if parsed_content is None and not text_content:
+                continue
+
+            yield AIResponse(
+                content=parsed_content if parsed_content is not None else text_content,
+                provider=Provider.GOOGLE,
+                metadata={"model": self.model, "is_stream_chunk": True},
+            )
 
         # suppress final usage-only emission


### PR DESCRIPTION
## Summary
- add optional structured output schema support to the Google audio client
- forward structured output config to Google GenAI requests and favor parsed responses
- ensure streamed responses emit parsed content when available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b5ab9a44832c8dfc7536daa55ca3